### PR TITLE
Add handling of non-CY in WDI

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,61 @@
+#' get_month_number
+#' @param month character: Month in %B format (e.g. 'March')
+#' @noRd
+get_month_number <- function(month) {
+
+  vapply(month, function(month){
+    d <- sprintf("1-%s-1960", month)
+    d <- as.Date(d, format = "%d-%B-%Y")
+    m <-  substr((as.character(d)), 6, 7)
+    m <- as.numeric(m)
+    return(m)
+  }, FUN.VALUE = numeric(1),
+     USE.NAMES = FALSE)
+
+}
+
+#' days_in_month
+#' @inheritParams get_month_number
+#' @param year numeric: Year
+#' @noRd
+days_in_month <- function(month, year) {
+
+  purrr::map2_dbl(month, year, .f = function(month, year){
+
+    # Early return if missing
+    if (is.na(month) || is.na(year)) return(NA_real_)
+
+    # Create date
+    d <- sprintf("1-%s-%s", month, year)
+    d <- as.Date(d, format = "%d-%B-%Y")
+
+    # Month number
+    m <-  substr((as.character(d)), 6, 7)
+
+    # Check for leap year
+    leap <- 0
+    if ((year %% 4 == 0 & year %% 100 != 0) | year %% 400 == 0)
+      leap <- 1
+
+    # Return the number of days in the month
+    return(switch(m,
+                  '01' = 31,
+                  '02' = 28 + leap,
+                  '03' = 31,
+                  '04' = 30,
+                  '05' = 31,
+                  '06' = 30,
+                  '07' = 31,
+                  '08' = 31,
+                  '09' = 30,
+                  '10' = 31,
+                  '11' = 30,
+                  '12' = 31))
+  })
+
+}
+
+
 #' Find latest dlw directory
 #' @noRd
 latest_dlw_dir <- function(dlwdir) {
@@ -21,7 +79,7 @@ latest_dlw_dir <- function(dlwdir) {
       ,
       # Name sections of filename into variables
       (cnames) := tstrsplit(orig, "_",
-        fixed = TRUE
+                            fixed = TRUE
       )
     ][
       !is.na(vermast) & !is.na(veralt)
@@ -87,8 +145,8 @@ chain_values <- function(dt, base_var, replacement_var, new_name, by = "country_
   # Check if any groups have missing values for
   # all observations of base_var
   dt_na <- dt[,
-    .SDcols = base_var, by = by,
-    .(all_na = purrr::map_lgl(.SD, anyNA))
+              .SDcols = base_var, by = by,
+              .(all_na = purrr::map_lgl(.SD, anyNA))
   ]
   dt <- data.table::merge.data.table(dt, dt_na, by = by)
 
@@ -101,26 +159,26 @@ chain_values <- function(dt, base_var, replacement_var, new_name, by = "country_
   # Create lag and lead columns by group
   dt$rep_var <- dt[[replacement_var]]
   dt[,
-    `:=`(
-      rep_var_lag = shift(rep_var),
-      rep_var_lead = shift(rep_var, type = "lead")
-    ),
-    by = by
+     `:=`(
+       rep_var_lag = shift(rep_var),
+       rep_var_lead = shift(rep_var, type = "lead")
+     ),
+     by = by
   ]
 
   # Create linking factors (growth values)
   dt[,
-    `:=`(
-      # linking factors back
-      fwd = (!is.na(rep_var) &
-        !is.na(rep_var_lag) &
-        n != 1) * (rep_var / rep_var_lag),
-      # linking factors forward
-      bck = (!is.na(rep_var) &
-        !is.na(rep_var_lead) &
-        n != .N) * (rep_var / rep_var_lead)
-    ),
-    by = by
+     `:=`(
+       # linking factors back
+       fwd = (!is.na(rep_var) &
+                !is.na(rep_var_lag) &
+                n != 1) * (rep_var / rep_var_lag),
+       # linking factors forward
+       bck = (!is.na(rep_var) &
+                !is.na(rep_var_lead) &
+                n != .N) * (rep_var / rep_var_lead)
+     ),
+     by = by
   ]
 
   # Chain forwards


### PR DESCRIPTION
Hi  @randrescastaneda, 

This PR adds handling of non calendar years in WDI, both for PCE and GDP.  Depends on a new manual xlsx located in the _aux/sna folder, but is otherwise self-contained. 

Closes #62

@tsamuel321 Attached are the "final" files with the FY/CY conversion for the specified countries. This has a lot of missing values, but those will either be replaced when chaining on data from other sources (e.g WEO, Maddison, SNA adjustments) or removed.  Mostly the same as I shared yesterday, but maybe good to take a final look at the PCE as well. Thanks. 


[wdi-gdp.csv](https://github.com/PIP-Technical-Team/pipaux/files/7940159/wdi-gdp.csv)
[wdi-pce.csv](https://github.com/PIP-Technical-Team/pipaux/files/7940160/wdi-pce.csv)
.