### PR TITLE
Add function to create income groups dataset

### DIFF
--- a/R/pip_income_groups.R
+++ b/R/pip_income_groups.R
@@ -11,7 +11,8 @@ pip_income_groups <- function(action = "update",
   msrdir <- paste0(maindir, "_aux/", measure, "/")
 
   if (action == "update") {
-    df <- haven::read_dta(paste0(msrdir, "CLASS.dta"))
+    u <- "https://github.com/PovcalNet-Team/Class/blob/master/OutputData/CLASS.dta?raw=true"
+    df <- haven::read_dta(u)
     df <- df[c('code', 'year_data', 'incgroup_historical',
                'fcv_historical', 'region_SSA')]
     names(df) <- c('country_code', 'year_data',

--- a/R/pip_income_groups.R
+++ b/R/pip_income_groups.R
@@ -1,0 +1,38 @@
+#' PIP income groups
+#'
+#' Update or load a dataset with historical income groups
+#'
+#' @inheritParams pip_prices
+#' @export
+pip_income_groups <- function(action = "update",
+                              force = FALSE,
+                              maindir = gls$PIP_DATA_DIR) {
+  measure <- "income_groups"
+  msrdir <- paste0(maindir, "_aux/", measure, "/")
+
+  if (action == "update") {
+    df <- haven::read_dta(paste0(msrdir, "CLASS.dta"))
+    df <- df[c('code', 'year_data', 'incgroup_historical')]
+    names(df)[1] <- 'country_code'
+    pip_sign_save(
+      x = df,
+      measure = measure,
+      msrdir = msrdir,
+      force = force
+    )
+  } else if (action == "load") {
+    df <- load_aux(
+      maindir = maindir,
+      measure = measure
+    )
+    return(df)
+  } else {
+    msg <- paste("action `", action, "` is not a valid action.")
+    rlang::abort(c(
+      msg,
+      i = "make sure you select `update` or `load`"
+    ),
+    class = "pipaux_error"
+    )
+  }
+}

--- a/R/pip_income_groups.R
+++ b/R/pip_income_groups.R
@@ -12,8 +12,12 @@ pip_income_groups <- function(action = "update",
 
   if (action == "update") {
     df <- haven::read_dta(paste0(msrdir, "CLASS.dta"))
-    df <- df[c('code', 'year_data', 'incgroup_historical')]
-    names(df)[1] <- 'country_code'
+    df <- df[c('code', 'year_data', 'incgroup_historical',
+               'fcv_historical', 'region_SSA')]
+    names(df) <- c('country_code', 'year_data',
+                   'incgroup_historical',
+                   'fcv_historical',
+                   'ssa_subregion_code')
     pip_sign_save(
       x = df,
       measure = measure,


### PR DESCRIPTION
Hi @randrescastaneda 

This adds a function to read from Daniel's `CLASS.dta` file and create a corresponding .fst file with the columns we need for PIP. 

The file will be needed for the regional calculation (to handled LIC / LMIC global censoring).  It might also have future use cases if want to calculate aggregates based on income groups etc (in which case we would need to think about how to add this to survey tables as well). 

I added a new measure folder called "income_groups" in the QA _aux folder. But let me know if you think it should be called something else. 

 See #65

**Update:** Marta S. pointed out that the `fcv_historical` (sometimes used for the PSPR) and `region_SSA` (for aggregation) columns might  come in handy in the future. Since they have nothing to do with income, it makes me even more uncertain of the "income_groups" folder / file name. Maybe we could just name it `class.fst` (like Daniel does), but on the other hand I don't really like having a function called `pip_class()` for this purpose. Let me know if you have feedback. 

cc: @danielmahler 